### PR TITLE
Add fromUrl and fromDockerHostEnvironmentVariable for overall MobyApi layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Moby API client built using [effect-ts](http://effect.website). If you want docu
 - [x] - local unix socket connections
 - [x] - http and https connections
 - [x] - ssh connections
+- [x] - `DOCKER_HOST` environment variable support
 - [x] - streaming (just like [dockerode](https://github.com/apocas/dockerode), streams are passed directly through to you)
 - [x] - tests, examples, and in-line JSDoc comments based on the moby api documentation
 - [x] - Strong focus on types and typescript support

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Scope } from "effect";
+import { Config, ConfigError, Effect, Layer, Scope, Secret } from "effect";
 
 import * as AgentHelpers from "./agent-helpers.js";
 import * as Configs from "./configs.js";
@@ -75,8 +75,99 @@ const layer = Layer.mergeAll(
     Volumes.layer
 );
 
+/** Creates a MobyApi layer from the provided connection agent */
 export const fromAgent = (agent: Effect.Effect<Scope.Scope, never, AgentHelpers.IMobyConnectionAgent>): MobyApi =>
     layer.pipe(Layer.provide(Layer.scoped(AgentHelpers.MobyConnectionAgent, agent)));
 
+/** Creates a MobyApi layer from the provided connection options */
 export const fromConnectionOptions = (connectionOptions: AgentHelpers.MobyConnectionOptions): MobyApi =>
     fromAgent(AgentHelpers.getAgent(connectionOptions));
+
+/**
+ * From
+ * https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-socket-option
+ *
+ * "The Docker client will honor the DOCKER_HOST environment variable to set the
+ * -H flag for the client"
+ *
+ * And then from
+ * https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-hostport-or-a-unix-socket
+ *
+ * "-H accepts host and port assignment in the following format:
+ * `tcp://[host]:[port][path]` or `unix://path`
+ *
+ * For example:
+ *
+ * - `unix://path/to/socket` -> Unix socket located at path/to/socket
+ * - When -H is empty, it will default to the same value as when no -H was passed
+ *   in
+ * - `http://host:port/path` -> HTTP connection on host:port and prepend path to
+ *   all requests
+ * - `https://host:port/path` -> HTTPS connection on host:port and prepend path to
+ *   all requests
+ * - `ssh://me@example.com:22/var/run/docker.sock` -> SSH connection to
+ *   example.com on port 22
+ */
+export const fromUrl = (
+    dockerHost: string
+): Layer.Layer<
+    Layer.Layer.Context<MobyApi> | never,
+    Layer.Layer.Error<MobyApi> | ConfigError.ConfigError,
+    Layer.Layer.Success<MobyApi>
+> => {
+    const url: URL = new URL(dockerHost);
+
+    if (url.protocol === "unix") {
+        return fromConnectionOptions({ connection: "unix", socketPath: url.pathname });
+    }
+
+    if (url.protocol === "ssh") {
+        return fromConnectionOptions({
+            connection: "ssh",
+            host: url.hostname,
+            username: url.username,
+            password: url.password,
+            remoteSocketPath: url.pathname,
+            port: url.port ? Number.parseInt(url.port) : 22,
+        });
+    }
+
+    if (url.protocol === "http") {
+        return fromConnectionOptions({
+            connection: "http",
+            host: url.hostname ?? "127.0.0.1",
+            port: url.port ? Number.parseInt(url.port) : 2375,
+            path: url.pathname,
+        });
+    }
+
+    if (url.protocol === "https") {
+        return fromConnectionOptions({
+            connection: "https",
+            host: url.hostname ?? "127.0.0.1",
+            port: url.port ? Number.parseInt(url.port) : 2376,
+            path: url.pathname,
+        });
+    }
+
+    if (url.protocol === "tcp") {
+        const path: string = url.pathname;
+        const host: string = url.hostname ?? "127.0.0.0.1";
+        const port: number = url.port ? Number.parseInt(url.port) : 2375;
+        return fromConnectionOptions({ connection: port === 2376 ? "https" : "http", host, port, path });
+    }
+
+    // Any other protocols are not supported
+    return Layer.fail(ConfigError.InvalidData([""], `Unsupported protocol ${url.protocol}`));
+};
+
+/** Creates a MobyApi layer from the DOCKER_HOST environment variable as a url */
+export const fromDockerHostEnvironmentVariable: Layer.Layer<
+    Layer.Layer.Context<MobyApi>,
+    Layer.Layer.Error<MobyApi> | ConfigError.ConfigError,
+    Layer.Layer.Success<MobyApi>
+> = Config.secret("DOCKER_HOST")
+    .pipe(Config.withDefault(Secret.fromString("unix:///var/run/docker.sock")))
+    .pipe(Config.map(Secret.value))
+    .pipe(Effect.map(fromUrl))
+    .pipe(Layer.unwrapEffect);


### PR DESCRIPTION
Allows you to construct the MobyApi layer from the `DOCKER_HOST` environment varialbe