### PR TITLE
Update ws and undici deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,10 +89,10 @@
         "ssh2": "1.17.0",
         "tsx": "4.23.7",
         "typescript": "7.0.2",
-        "undici": "8.9.0",
+        "undici": "8.10.0",
         "vite": "8.2.0",
         "vitest": "4.1.10",
-        "ws": "8.21.1"
+        "ws": "8.21.2"
     },
     "peerDependencies": {
         "@effect/platform-browser": "4.0.0-beta.103",
@@ -113,8 +113,8 @@
     },
     "optionalDependencies": {
         "ssh2": "^1.17.0",
-        "undici": "^8.9.0",
-        "ws": "^8.21.1"
+        "undici": "^8.10.0",
+        "ws": "^8.21.2"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,11 +102,11 @@ importers:
         specifier: ^1.17.0
         version: 1.17.0
       undici:
-        specifier: ^8.9.0
-        version: 8.9.0
+        specifier: ^8.10.0
+        version: 8.10.0
       ws:
-        specifier: ^8.21.1
-        version: 8.21.1
+        specifier: ^8.21.2
+        version: 8.21.2
 
 packages:
 
@@ -2515,8 +2515,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.9.0:
-    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
@@ -2637,8 +2637,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2974,7 +2974,7 @@ snapshots:
     dependencies:
       '@types/ws': 8.18.1
       effect: 4.0.0-beta.103(patch_hash=2a1d4188619556d9126df7d4e10c74e9ce24a6a606e80ffeb22aacaa96f27c0b)
-      ws: 8.21.1
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2985,7 +2985,7 @@ snapshots:
       effect: 4.0.0-beta.103(patch_hash=2a1d4188619556d9126df7d4e10c74e9ce24a6a606e80ffeb22aacaa96f27c0b)
       ioredis: 5.11.1
       mime: 4.1.0
-      undici: 8.9.0
+      undici: 8.10.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4893,7 +4893,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.9.0: {}
+  undici@8.10.0: {}
 
   universalify@0.1.2: {}
 
@@ -4962,7 +4962,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@8.21.1: {}
+  ws@8.21.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Bumps `ws` 8.21.1 → 8.21.2 and `undici` 8.9.0 → 8.10.0 in both `devDependencies` and `optionalDependencies`, with the lockfile regenerated.

`@types/ws` is already at latest (8.18.1).