### PR TITLE
Add changeset for type-aware lint cleanups

### DIFF
--- a/.changeset/spicy-donuts-repeat.md
+++ b/.changeset/spicy-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"the-moby-effect": patch
+---
+
+Code cleanups across the demux, endpoints, engines, and platforms internals from enabling the type-aware Effect lints. No intended behavior changes.


### PR DESCRIPTION
Adds a patch changeset covering the src cleanups from #352 so they get released.