### PR TITLE
Clear the remaining type-aware Effect lint reports

### DIFF
--- a/.changeset/brave-hounds-glow.md
+++ b/.changeset/brave-hounds-glow.md
@@ -1,0 +1,5 @@
+---
+"the-moby-effect": patch
+---
+
+Clear the remaining type-aware Effect lint reports: endpoint query and filter schemas now use `Schema.Finite`/`Schema.FiniteFromString` so `NaN` and `Infinity` are rejected, an `Effect.sync` returning a constant became `Effect.succeed`, an ssh dispatcher release that awaited nothing became `Effect.sync`, and the deliberate patterns (Promise/callback adapters, wall-clock reads in tests, Node agent type imports, the dind channel coercion, console output in the callback examples) carry scoped disables explaining why.

--- a/examples/callbacks/build-image.ts
+++ b/examples/callbacks/build-image.ts
@@ -1,4 +1,6 @@
 // Run with: pnpx tsx examples/callbacks/build-image.ts
+// Printing to the console is the point of these callback-API examples.
+// @effect-diagnostics globalConsole:off
 
 import { Function, Stream } from "effect";
 

--- a/examples/callbacks/container-with-volume.ts
+++ b/examples/callbacks/container-with-volume.ts
@@ -1,4 +1,6 @@
 // Run with: pnpx tsx examples/callbacks/container-with-volume.ts
+// Printing to the console is the point of these callback-API examples.
+// @effect-diagnostics globalConsole:off
 
 import { Exit } from "effect";
 

--- a/examples/callbacks/pull-image.ts
+++ b/examples/callbacks/pull-image.ts
@@ -1,4 +1,6 @@
 // Run with: pnpx tsx examples/callbacks/pull-image.ts
+// Printing to the console is the point of these callback-API examples.
+// @effect-diagnostics globalConsole:off
 
 import { Callbacks, DockerEngine } from "the-moby-effect";
 

--- a/src/Callbacks.ts
+++ b/src/Callbacks.ts
@@ -115,6 +115,8 @@ export function runCallback<R = never>(services: Context.Context<R>, arity?: 0 |
  * @since 1.0.0
  * @category Callbacks
  */
+// This module is deliberately a callback adapter over the Effect API.
+// @effect-diagnostics-next-line asyncFunction:off
 export const callbackClient = async <E1, E2>(
     layer: (
         connectionOptions: MobyConnection.MobyConnectionOptions

--- a/src/Promises.ts
+++ b/src/Promises.ts
@@ -23,6 +23,8 @@ import * as MobyConvey from "./MobyConvey.ts";
  * @since 1.0.0
  * @category Promises
  */
+// This module is deliberately a Promise adapter over the Effect API.
+// @effect-diagnostics-next-line asyncFunction:off
 export const promiseClient = async <E1, E2>(
     layer: (
         connectionOptions: MobyConnection.MobyConnectionOptions

--- a/src/internal/demux/hijack.ts
+++ b/src/internal/demux/hijack.ts
@@ -31,7 +31,7 @@ export const hijackResponseUnsafe = (
                 );
             }
 
-            return nodeSocketLazy.fromDuplex(Effect.sync(() => socket));
+            return nodeSocketLazy.fromDuplex(Effect.succeed(socket));
         }
     );
 

--- a/src/internal/endpoints/containers.ts
+++ b/src/internal/endpoints/containers.ts
@@ -44,7 +44,7 @@ export const ListFilters = Schema.fromJsonString(
         ancestor: Schema.optional(Schema.Array(Schema.String)),
         before: Schema.optional(Schema.Array(Schema.String)),
         expose: Schema.optional(Schema.Array(Schema.String)),
-        exited: Schema.optional(Schema.Array(Schema.NumberFromString)),
+        exited: Schema.optional(Schema.Array(Schema.FiniteFromString)),
         health: Schema.optional(Schema.Array(ContainerHealth.fields["Status"])),
         identifier: Schema.optional(Schema.Array(ContainerIdentifier)),
         // isolation: Schema.optional(Schema.Array(ContainerHostConfig.fields["Isolation"])),
@@ -71,7 +71,7 @@ export const PruneFilters = Schema.fromJsonString(
 const listContainersEndpoint = HttpApiEndpoint.get("list", "/json", {
     query: {
         all: Schema.optional(Schema.Boolean),
-        limit: Schema.optional(Schema.Number),
+        limit: Schema.optional(Schema.Finite),
         size: Schema.optional(Schema.Boolean),
         filters: Schema.optional(ListFilters),
     },
@@ -132,8 +132,8 @@ const logsContainerEndpoint = HttpApiEndpoint.get("logs", "/:identifier/logs", {
         follow: Schema.optional(Schema.Boolean),
         stdout: Schema.optional(Schema.Boolean),
         stderr: Schema.optional(Schema.Boolean),
-        since: Schema.optional(Schema.Number),
-        until: Schema.optional(Schema.Number),
+        since: Schema.optional(Schema.Finite),
+        until: Schema.optional(Schema.Finite),
         timestamps: Schema.optional(Schema.Boolean),
         tail: Schema.optional(Schema.String),
     },
@@ -182,8 +182,8 @@ const statsContainerEndpoint = HttpApiEndpoint.get("stats", "/:identifier/stats"
 const resizeContainerEndpoint = HttpApiEndpoint.post("resize", "/:identifier/resize", {
     params: { identifier: ContainerIdentifier },
     query: {
-        h: Schema.optional(Schema.Number),
-        w: Schema.optional(Schema.Number),
+        h: Schema.optional(Schema.Finite),
+        w: Schema.optional(Schema.Finite),
     },
     success: HttpApiSchema.Empty(200), // 200 OK
     error: [
@@ -213,7 +213,7 @@ const stopContainerEndpoint = HttpApiEndpoint.post("stop", "/:identifier/stop", 
     params: { identifier: ContainerIdentifier },
     query: {
         signal: Schema.optional(Schema.String),
-        t: Schema.optional(Schema.Number),
+        t: Schema.optional(Schema.Finite),
     },
     success: [
         HttpApiSchema.Empty(204), // 204 No Content
@@ -230,7 +230,7 @@ const restartContainerEndpoint = HttpApiEndpoint.post("restart", "/:identifier/r
     params: { identifier: ContainerIdentifier },
     query: {
         signal: Schema.optional(Schema.String),
-        t: Schema.optional(Schema.Number),
+        t: Schema.optional(Schema.Finite),
     },
     success: HttpApiSchema.Empty(204), // 204 No Content
     error: [

--- a/src/internal/endpoints/execs.ts
+++ b/src/internal/endpoints/execs.ts
@@ -58,8 +58,8 @@ const startExecEndpoint = HttpApiEndpoint.post("start", "/exec/:id/start", {
 const resizeExecEndpoint = HttpApiEndpoint.post("resize", "/exec/:id/resize", {
     params: { id: ExecIdentifier },
     query: {
-        h: Schema.Number,
-        w: Schema.Number,
+        h: Schema.Finite,
+        w: Schema.Finite,
     },
     success: HttpApiSchema.Empty(200), // 200 OK
     error: [

--- a/src/internal/endpoints/filters.ts
+++ b/src/internal/endpoints/filters.ts
@@ -19,8 +19,8 @@ export const StringFilter = Schema.Tuple([Schema.String]).pipe(
 );
 
 /** @internal */
-export const NumberFilter = Schema.Tuple([Schema.NumberFromString]).pipe(
-    Schema.decodeTo(Schema.Number, {
+export const NumberFilter = Schema.Tuple([Schema.FiniteFromString]).pipe(
+    Schema.decodeTo(Schema.Finite, {
         decode: SchemaGetter.transform(([value]: readonly [number]) => value),
         encode: SchemaGetter.transform((value: number) => [value] as const),
     })

--- a/src/internal/endpoints/images.ts
+++ b/src/internal/endpoints/images.ts
@@ -72,16 +72,16 @@ const buildImageEndpoint = HttpApiEndpoint.post("build", "/build", {
         pull: Schema.optional(Schema.String),
         rm: Schema.optional(Schema.Boolean),
         forcerm: Schema.optional(Schema.Boolean),
-        memory: Schema.optional(Schema.Number),
-        memswap: Schema.optional(Schema.Number),
-        cpushares: Schema.optional(Schema.Number),
+        memory: Schema.optional(Schema.Finite),
+        memswap: Schema.optional(Schema.Finite),
+        cpushares: Schema.optional(Schema.Finite),
         cpusetcpus: Schema.optional(Schema.String),
-        cpuperiod: Schema.optional(Schema.Number),
-        cpuquota: Schema.optional(Schema.Number),
+        cpuperiod: Schema.optional(Schema.Finite),
+        cpuquota: Schema.optional(Schema.Finite),
         buildargs: Schema.optional(
             Schema.fromJsonString(Schema.Record(Schema.String, Schema.NullishOr(Schema.String)))
         ),
-        shmsize: Schema.optional(Schema.Number),
+        shmsize: Schema.optional(Schema.Finite),
         squash: Schema.optional(Schema.Boolean),
         labels: Schema.optional(Schema.String),
         networkmode: Schema.optional(Schema.String),
@@ -119,7 +119,7 @@ export const BuildPruneFilters = Schema.fromJsonString(
 /** @see https://docs.docker.com/reference/api/engine/latest/#tag/Image/operation/BuildPrune */
 const buildPruneEndpoint = HttpApiEndpoint.post("buildPrune", "/build/prune", {
     query: {
-        "keep-storage": Schema.optional(Schema.Number),
+        "keep-storage": Schema.optional(Schema.Finite),
         all: Schema.optional(Schema.Boolean),
         filters: Schema.optional(BuildPruneFilters),
     },
@@ -216,7 +216,7 @@ const deleteImageEndpoint = HttpApiEndpoint.delete("delete", "/images/:name", {
 const searchImagesEndpoint = HttpApiEndpoint.get("search", "/images/search", {
     query: {
         term: Schema.String,
-        limit: Schema.optional(Schema.Number),
+        limit: Schema.optional(Schema.Finite),
         filters: Schema.optional(SearchFilters),
     },
     success: Schema.Array(RegistrySearchResult), // 200 OK

--- a/src/internal/endpoints/nodes.ts
+++ b/src/internal/endpoints/nodes.ts
@@ -63,7 +63,7 @@ const deleteNodeEndpoint = HttpApiEndpoint.delete("delete", "/:id", {
 /** @see https://docs.docker.com/reference/api/engine/latest/#tag/Node/operation/NodeUpdate */
 const updateNodeEndpoint = HttpApiEndpoint.post("update", "/:id/update", {
     params: { id: Schema.String },
-    query: { version: Schema.Number },
+    query: { version: Schema.Finite },
     payload: SwarmNodeSpec,
     success: HttpApiSchema.Empty(200), // 200 OK
     error: [

--- a/src/internal/endpoints/plugins.ts
+++ b/src/internal/endpoints/plugins.ts
@@ -73,7 +73,7 @@ const deletePluginEndpoint = HttpApiEndpoint.delete("delete", "/:name", {
 /** @see https://docs.docker.com/reference/api/engine/latest/#tag/Plugin/operation/PluginEnable */
 const enablePluginEndpoint = HttpApiEndpoint.post("enable", "/:name/enable", {
     params: { name: Schema.String },
-    query: { timeout: Schema.optional(Schema.Number) },
+    query: { timeout: Schema.optional(Schema.Finite) },
     success: HttpApiSchema.Empty(200), // 200 OK
     error: [
         NotFound, // 404 No such plugin

--- a/src/internal/endpoints/services.ts
+++ b/src/internal/endpoints/services.ts
@@ -84,7 +84,7 @@ const inspectServiceEndpoint = HttpApiEndpoint.get("inspect", "/:id", {
 const updateServiceEndpoint = HttpApiEndpoint.post("update", "/:id/update", {
     params: { id: Schema.String },
     query: {
-        version: Schema.Number,
+        version: Schema.Finite,
         rollback: Schema.optional(Schema.String),
         registryAuthFrom: Schema.optional(Schema.String),
     },
@@ -107,7 +107,7 @@ const logsServiceEndpoint = HttpApiEndpoint.get("logs", "/:id/logs", {
         follow: Schema.optional(Schema.Boolean),
         stdout: Schema.optional(Schema.Boolean),
         stderr: Schema.optional(Schema.Boolean),
-        since: Schema.optional(Schema.Number),
+        since: Schema.optional(Schema.Finite),
         timestamps: Schema.optional(Schema.Boolean),
         tail: Schema.optional(Schema.String),
     },

--- a/src/internal/endpoints/tasks.ts
+++ b/src/internal/endpoints/tasks.ts
@@ -57,7 +57,7 @@ const logsTaskEndpoint = HttpApiEndpoint.get("logs", "/:id/logs", {
         follow: Schema.optional(Schema.Boolean),
         stdout: Schema.optional(Schema.Boolean),
         stderr: Schema.optional(Schema.Boolean),
-        since: Schema.optional(Schema.Number),
+        since: Schema.optional(Schema.Finite),
         timestamps: Schema.optional(Schema.Boolean),
         tail: Schema.optional(Schema.String),
     },

--- a/src/internal/endpoints/volumes.ts
+++ b/src/internal/endpoints/volumes.ts
@@ -80,7 +80,7 @@ const deleteVolumeEndpoint = HttpApiEndpoint.delete("delete", "/:name", {
 /** @see https://docs.docker.com/reference/api/engine/latest/#tag/Volume/operation/VolumeUpdate */
 const updateVolumeEndpoint = HttpApiEndpoint.put("update", "/:name", {
     params: { name: Schema.String },
-    query: { version: Schema.Number },
+    query: { version: Schema.Finite },
     payload: ClusterVolumeSpec,
     success: HttpApiSchema.Empty(200), // 200 OK
     error: [

--- a/src/internal/engines/dind.ts
+++ b/src/internal/engines/dind.ts
@@ -105,7 +105,8 @@ const makeDindBinds = <ExposeDindBy extends MobyConnection.MobyConnectionOptions
 > =>
     // The conditional error/requirement channels below depend on `ExposeDindBy`, which the
     // compiler cannot follow through the generator, so the result is coerced.
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    // oxlint-disable typescript/no-unsafe-type-assertion
+    // @effect-diagnostics-next-line unsafeEffectTypeAssertion:off
     Effect.gen(function* () {
         const acquireScopedVolume = Effect.acquireRelease(
             MobyEndpoints.Volumes.use((volumes) => volumes.create({})),
@@ -142,6 +143,7 @@ const makeDindBinds = <ExposeDindBy extends MobyConnection.MobyConnectionOptions
         | Scope.Scope
         | (ExposeDindBy extends "socket" ? Path.Path | FileSystem.FileSystem : never)
     >;
+// oxlint-enable typescript/no-unsafe-type-assertion
 
 /**
  * Since the dind containers do not have health checks, we must wait until a

--- a/src/internal/platforms/node.ts
+++ b/src/internal/platforms/node.ts
@@ -7,7 +7,10 @@ import * as Function from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as Socket from "effect/unstable/socket/Socket";
 
+// These type-only imports feed the Node http/https agent options that this platform adapter exists to build.
+// @effect-diagnostics-next-line nodeBuiltinImport:off
 import type * as http from "node:http";
+// @effect-diagnostics-next-line nodeBuiltinImport:off
 import type * as https from "node:https";
 import type * as net from "node:net";
 import type * as stream from "node:stream";

--- a/src/internal/platforms/undici.ts
+++ b/src/internal/platforms/undici.ts
@@ -107,7 +107,7 @@ export const makeSshDispatcher: (
 
     const acquire = Effect.sync(() => new undiciLazy.Agent({ connect: connector }));
     const release = (_agent: undici.Dispatcher) =>
-        Effect.promise(async () => {
+        Effect.sync(() => {
             sshClient.end();
             sshClient.destroy();
             // await agent.close();

--- a/src/internal/schemas/number.ts
+++ b/src/internal/schemas/number.ts
@@ -40,7 +40,7 @@ const sentinelTransformation = SchemaTransformation.transform({
  */
 export const NumberFromWireString = Schema.String.annotate({
     expected: "a string that will be decoded as a number and sent over the wire as a bare JSON number",
-}).pipe(Schema.decodeTo(Schema.Number, sentinelTransformation.compose(SchemaTransformation.numberFromString)));
+}).pipe(Schema.decodeTo(Schema.Finite, sentinelTransformation.compose(SchemaTransformation.numberFromString)));
 
 /**
  * A bigint that crosses the wire as a bare JSON number but is carried as a

--- a/src/internal/schemas/port.ts
+++ b/src/internal/schemas/port.ts
@@ -30,7 +30,7 @@ export const PortSet = Schema.Record(PortWithMaybeProtocol.from, Schema.ObjectKe
  */
 export class PortBinding extends Schema.Class<PortBinding>("PortBinding")(
     {
-        HostPort: Schema.NumberFromString.pipe(Schema.decodeTo(Port)),
+        HostPort: Schema.FiniteFromString.pipe(Schema.decodeTo(Port)),
         HostIp: Schema.optional(Schema.Union([Schema.Literal(""), Address])),
     },
     {

--- a/test/setup-global.ts
+++ b/test/setup-global.ts
@@ -12,6 +12,8 @@ import { DockerEngine, MobyConnection, MobyConvey } from "the-moby-effect";
 import { testMatrix } from "./shared-global.js";
 
 const makePlatformDockerLayer = Function.pipe(
+    // The platform layer must be chosen before any Effect runtime exists to read Config from.
+    // @effect-diagnostics-next-line processEnv:off
     Match.value(process.env["__PLATFORM_VARIANT"] ?? "node-24.x"),
     Match.when("bun", () => DockerEngine.layerBun),
     Match.when("deno", () => DockerEngine.layerDeno),
@@ -25,6 +27,8 @@ const localDocker = Function.pipe(
     Layer.unwrap
 );
 
+// Vitest global setup hooks are async functions by contract.
+// @effect-diagnostics-next-line asyncFunction:off
 export const setup = async function ({ provide }: TestProject): Promise<void> {
     await Effect.gen(function* () {
         const platformVariant = yield* Config.literals(

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -44,7 +44,7 @@ describe.each(testMatrix)(
                             Schema.Literal("docker.io/library/docker:dind-rootless"),
                             Schema.TemplateLiteral(["docker.io/library/docker:", Schema.String, "-dind-rootless"]),
                         ]).pipe(
-                            Schema.decodeTo(Schema.Result(Schema.NumberFromString, Schema.Literal("latest")), {
+                            Schema.decodeTo(Schema.Result(Schema.FiniteFromString, Schema.Literal("latest")), {
                                 decode: SchemaGetter.transform((str) =>
                                     str === "docker.io/library/docker:dind-rootless"
                                         ? Result.fail("latest" as const)
@@ -91,6 +91,8 @@ describe.each(testMatrix)(
 
                         // Gather the event
                         const system = yield* MobyEndpoints.System;
+                        // The daemon compares against real wall-clock time, not the virtual TestClock.
+                        // @effect-diagnostics-next-line globalDateInEffect:off
                         const stream = system.events({ until: `${Date.now()}` }).pipe(Stream.take(1));
                         const data = yield* Stream.runHead(stream);
                         expect(Option.getOrUndefined(data)).toBeDefined();
@@ -101,6 +103,8 @@ describe.each(testMatrix)(
                     Effect.gen(function* () {
                         const system = yield* MobyEndpoints.System;
                         const fiber = yield* system
+                            // The daemon compares against real wall-clock time, not the virtual TestClock.
+                            // @effect-diagnostics-next-line globalDateInEffect:off
                             .events({ since: `${Date.now()}` })
                             .pipe(Stream.take(1), Stream.runHead, Effect.forkChild);
 

--- a/test/volumes.test.ts
+++ b/test/volumes.test.ts
@@ -40,6 +40,8 @@ describe.each(testMatrix)(
                         const testData = yield* volumes.create({ Name: "testVolume" });
                         expect(testData.Name).toBe("testVolume");
                         expect(testData.CreatedAt).toBeDefined();
+                        // CreatedAt is stamped by the daemon with real wall-clock time, not the virtual TestClock.
+                        // @effect-diagnostics-next-line globalDateInEffect:off
                         expect(testData.CreatedAt!.getTime()).toBeLessThanOrEqual(Date.now());
                     })
                 );
@@ -90,6 +92,8 @@ describe.each(testMatrix)(
                         const testData = yield* volumes.create({ Name: "testVolume", Labels: { testLabel: "test" } });
                         expect(testData.Name).toBe("testVolume");
                         expect(testData.CreatedAt).toBeDefined();
+                        // CreatedAt is stamped by the daemon with real wall-clock time, not the virtual TestClock.
+                        // @effect-diagnostics-next-line globalDateInEffect:off
                         expect(testData.CreatedAt!.getTime()).toBeLessThanOrEqual(Date.now());
                         expect(testData.Labels).toEqual({ testLabel: "test" });
                     })


### PR DESCRIPTION
Follow-up to #352/#354, taking `pnpm check` from 63 diagnostics down to only the 15 deliberately kept `lazyEffect` suggestions.

Real fixes:
- 29 `schemaNumber`: endpoint query/filter schemas, `schemas/number.ts`, `schemas/port.ts`, and one test schema move from `Schema.Number`/`Schema.NumberFromString` to `Schema.Finite`/`Schema.FiniteFromString`, rejecting `NaN`/`Infinity` for ports, timestamps, sizes, and version counters.
- `syncToSucceed`: the hijack demux wraps its captured socket with `Effect.succeed`.
- `asyncFunction` in `undici.ts`: the ssh dispatcher release awaited nothing, so it becomes `Effect.sync`.

Scoped disables with rationale comments for the deliberate patterns:
- `Promises.ts`/`Callbacks.ts` stay async; they exist to be Promise/callback adapters.
- The test `Date.now()` reads are intentionally wall-clock: `it.effect` installs a virtual `TestClock` (starts at epoch 0) while the daemon stamps and compares real time, so a `Clock` rewrite would break them.
- `platforms/node.ts` type-only `node:http`/`node:https` imports, the vitest global setup contract, the documented dind channel coercion (now silenced for both linters via an oxlint region disable), and console output in the callback examples.

`pnpm check`, `pnpm lint`, and `pnpm circular` all pass. The vitest suite was not run; it needs a live daemon and the dind matrix, and the only behavior change beyond validation tightening is two equivalent `Effect.sync`/`succeed` swaps.